### PR TITLE
PROD-1012: Return total amount of the results found

### DIFF
--- a/app/model/api/api-feeds.php
+++ b/app/model/api/api-feeds.php
@@ -25,7 +25,7 @@ class Ai1ec_Api_Feeds extends Ai1ec_Api_Abstract {
 	 * Getting a suggested events list.
 	 * @return object Response body in JSON.
 	 */
-	public function get_suggested_events( $page = 0, $max = 8 ) {
+	public function get_suggested_events( $page = 1, $max = 8 ) {
 		$calendar_id = $this->_get_ticket_calendar();
 		if ( 0 >= $calendar_id ) {
 			return null;
@@ -49,7 +49,17 @@ class Ai1ec_Api_Feeds extends Ai1ec_Api_Abstract {
 			true //decode body response
 		);
 		if ( $this->is_response_success( $response ) ) {
-			return $response->body->data; 	
+			// $response->body format
+			// [total] => 10
+			// [per_page] => 8
+			// [current_page] => 1
+			// [last_page] => 2
+			// [next_page_url] => http://dev.time.ly:882/api/calendars/4/discover/events?page=2
+			// [prev_page_url] => 
+			// [from] => 1
+			// [to] => 8
+			// [data] => Array
+			return $response->body; 	
 		}  else {
 			$this->save_error_notification( 
 				$response, 

--- a/lib/calendar-feed/suggested.php
+++ b/lib/calendar-feed/suggested.php
@@ -46,7 +46,7 @@ class Ai1ecSuggestedConnectorPlugin extends Ai1ec_Connector_Plugin {
 		$this->render_opening_div_of_tab();
 	
 		$api           = $this->_registry->get( 'model.api.api-feeds' );
-		$feeds         = $api->get_suggested_events();
+		$events        = $api->get_suggested_events();
 		$loader        = $this->_registry->get( 'theme.loader' );
 		$event_actions = $loader->get_file(
 			'plugins/suggested/event_actions.php',
@@ -56,7 +56,9 @@ class Ai1ecSuggestedConnectorPlugin extends Ai1ec_Connector_Plugin {
 		$feeds_list    = $loader->get_file(
 			'plugins/suggested/feeds_list.php',
 			array(
-				'suggested_feeds' => $feeds,
+				'suggested_feeds' => $events->data,
+				'total_events'    => $events->total,
+				'last_page'       => $events->last_page,
 				'event_actions'   => $event_actions
 			),
 			true
@@ -105,7 +107,7 @@ class Ai1ecSuggestedConnectorPlugin extends Ai1ec_Connector_Plugin {
 	 */
 	public function map_updated() {
 		$api           = $this->_registry->get( 'model.api.api-feeds' );
-		$feeds         = $api->get_suggested_events();
+		$events        = $api->get_suggested_events();
 		$loader        = $this->_registry->get( 'theme.loader' );
 		$event_actions = $loader->get_file(
 			'plugins/suggested/event_actions.php',
@@ -115,7 +117,9 @@ class Ai1ecSuggestedConnectorPlugin extends Ai1ec_Connector_Plugin {
 		$feeds_list    = $loader->get_file(
 			'plugins/suggested/feeds_list.php',
 			array(
-				'suggested_feeds' => $feeds,
+				'suggested_feeds' => $events->data,
+				'total_events'    => $events->total,
+				'last_page'       => $events->last_page,
 				'event_actions'   => $event_actions
 			),
 			true

--- a/lib/import-export/api-ics.php
+++ b/lib/import-export/api-ics.php
@@ -253,7 +253,7 @@ class Ai1ec_Api_Ics_Import_Export_Engine
 			}
 			if ( ! isset( $data['contact_name'] ) || ! $data['contact_name'] ) {
 				// If no contact name, default to organizer property.
-				$data['contact_name']    = $organizer;
+				$data['contact_name']    = $e->ical_organizer;
 			}
 
 			$organizer = $e->ical_organizer;

--- a/tests/test-feeds.php
+++ b/tests/test-feeds.php
@@ -60,9 +60,10 @@ class FeedsTests extends BaseTestCase {
 
 		$this->api_sign();
 
-		$api   = $ai1ec_registry->get( 'model.api.api-feeds' );
-		$feeds = $api->get_suggested_events(0, 1);
-		
+		$api    = $ai1ec_registry->get( 'model.api.api-feeds' );
+		$result = $api->get_suggested_events();
+		$this->assertNotNull( $result, "Result of get_suggested_events is null" );
+		$feeds  = $result->data;	
 		$this->assertArrayNotEmpty( $feeds, "Feeds list is empty" );		
 	}
 
@@ -81,8 +82,9 @@ class FeedsTests extends BaseTestCase {
 		$_POST[ 'lat2' ] = 237;
 		$_POST[ 'lng2' ] = -327;
 
-		$feeds = $api->get_suggested_events(0, 1);
-		
+		$result = $api->get_suggested_events();
+		$this->assertNotNull( $result, "Result of get_suggested_events is null" );
+		$feeds  = $result->data;
 		$this->assertNotNull( $feeds, "Feeds list is empty" );		
 	}
 }


### PR DESCRIPTION
Hi Pavel.

We didn't need to change the API, the Laravel pagination feature was already returning the number of events and even another information, I just change the core plugin to get these informations.