### PR TITLE
PROD-1027: Fixed clone and clone to draft row actions. The Duplicate …

### DIFF
--- a/app/controller/front.php
+++ b/app/controller/front.php
@@ -536,7 +536,7 @@ class Ai1ec_Front_Controller {
 		$dispatcher->register_action(
 			'post_row_actions',
 			array( 'model.event.parent', 'post_row_actions' ),
-			10,
+			100,
 			2
 		);
 		// Category colors
@@ -719,7 +719,7 @@ class Ai1ec_Front_Controller {
 			$dispatcher->register_filter(
 				'post_row_actions',
 				array( 'clone.renderer-helper', 'ai1ec_duplicate_post_make_duplicate_link_row' ),
-				10,
+				100,
 				2
 			);
 			$dispatcher->register_action(


### PR DESCRIPTION
PROD-1027: Fixed clone and clone to draft row actions when the Plugin Duplicate Post is installed. The Duplicate Post plugin was overriding these row actions by their custom actions, so, I just increased the priority of our function to override their rows actions instead of then override our actions only for our Post Type.