### PR TITLE
Update constant.php

### DIFF
--- a/app/config/constants.php
+++ b/app/config/constants.php
@@ -147,7 +147,7 @@ function ai1ec_initiate_constants( $ai1ec_base_dir, $ai1ec_base_url ) {
 	if ( ! defined( 'AI1EC_TWIG_CACHE_PATH' ) ) {
 		define(
 		'AI1EC_TWIG_CACHE_PATH',
-		AI1EC_CACHE_PATH . DIRECTORY_SEPARATOR . 'twig' .
+		AI1EC_CACHE_PATH . 'twig' .
 			DIRECTORY_SEPARATOR
 		);
 	}


### PR DESCRIPTION
Removed DIRECTORY_SEPARATOR from EDIT AI1EC_TWIG_CACHE_PATH, because it add add a second slash in path before twig directory