### PR TITLE
(PROD-1160) Returned back avatar styling in event details

### DIFF
--- a/public/themes-ai1ec/vortex/less/event.less
+++ b/public/themes-ai1ec/vortex/less/event.less
@@ -115,8 +115,7 @@
 	line-height: @event-line-height;
 	// Event avatar/featured image.
 	.ai1ec-event-avatar {
-		margin: auto;
-		max-width: 25%;
+		max-width: 40%;
 		img {
 			max-width: 300px;
 			max-height: 300px;

--- a/public/themes-ai1ec/vortex/twig/event-single.twig
+++ b/public/themes-ai1ec/vortex/twig/event-single.twig
@@ -6,16 +6,6 @@
 
 <a id="ai1ec-event"></a>
 
-{% if not hide_featured_image %}
-	{% if content_img_url is empty %}
-		{{ event | avatar( [
-			'post_thumbnail',
-			'location_avatar',
-			'category_avatar'
-		], 'timely', false ) | raw }}
-	{% endif %}
-{% endif %}
-
 <div class="ai1ec-actions">
 	<div class="ai1ec-btn-group-vertical ai1ec-clearfix">
 		{{ back_to_calendar | raw }}
@@ -210,6 +200,16 @@
 {% else %}
 		</div>{# /.ai1ec-col-sm-7 #}
 	</div>{# /.ai1ec-event-details.ai1ec-row #}
+{% endif %}
+
+{% if not hide_featured_image %}
+	{% if content_img_url is empty %}
+		{{ event | avatar( [
+			'post_thumbnail',
+			'location_avatar',
+			'category_avatar'
+		], 'timely alignleft', false ) | raw }}
+	{% endif %}
 {% endif %}
 
 {% if API_URL is not empty %}


### PR DESCRIPTION
That was changed in this commit (when we merged ticketing changes to develop):

https://github.com/thenly/all-in-one-event-calendar/commit/6b991bbe41b0a68a46c2a76b14668dcdebebb3c5#diff-053603d34c51b2b27c1f2351ea68aab1

I returned the way image is displayed there.  