### PR TITLE
The new version of the core plugin was making the legacy events (crea…

### DIFF
--- a/app/model/api/api-ticketing.php
+++ b/app/model/api/api-ticketing.php
@@ -522,7 +522,7 @@ class Ai1ec_Api_Ticketing extends Ai1ec_Api_Abstract {
 			if ( isset( $data[self::ATTR_ACCOUNT] ) ) {
 				return ( $this->get_current_account() != $data[self::ATTR_ACCOUNT] );
 			} else {
-				return true;
+				return false;
 			}
 		} else {
 			return null;


### PR DESCRIPTION
…ted with old version) inaccessible, showing the message "This Event was created using a different account . Changes are not allowed"