### PR TITLE
The new version of the core plugin was making the legacy events (crea…

### DIFF
--- a/app/model/api/api-ticketing.php
+++ b/app/model/api/api-ticketing.php
@@ -525,7 +525,7 @@ class Ai1ec_Api_Ticketing extends Ai1ec_Api_Abstract {
 				return false;
 			}
 		} else {
-			return null;
+			return false;
 		}
 	}
 


### PR DESCRIPTION
…ted with old version) inaccessible, showing the message "This Event was created using a different account . Changes are not allowed"