### PR TITLE
PROD-1334: Fixing events with No end time set. If the event starts at 11:45PM, it would show duplicated on the next day

### DIFF
--- a/app/model/event.php
+++ b/app/model/event.php
@@ -125,7 +125,7 @@ class Ai1ec_Event extends Ai1ec_Base {
 		$end   = $this->_registry->get( 'date.time', $start );
 		$end->set_time(
 			$start->format( 'H' ),
-			$start->format( 'i' ) + 30,
+			$start->format( 'i' ) + 15,
 			$start->format( 's' )
 		);
 		$this->set( 'end', $end );


### PR DESCRIPTION
… 11:45PM, it would show duplicated on the next day