### PR TITLE
PROD-1906: Time.ly simply ignores timezones and publishes as UTC when…

### DIFF
--- a/app/view/event/single.php
+++ b/app/view/event/single.php
@@ -50,38 +50,12 @@ class Ai1ec_View_Event_Single extends Ai1ec_Base {
 			nl2br( $location->get_location( $event ) ),
 			$event
 		);
+		$default_tz = $this->_registry->get( 'date.timezone' )->get_default_timezone();		
 		$timezone_info = array(
-			'show_timezone'       => false,
-			'text_timezone_title' => null,
-			'event_timezone'      => null,
+			'using_calendar_tz'   => $this->_registry->get( 'model.settings' )->get( 'always_use_calendar_timezone' ),
+			'event_timezone'      => str_replace( '_', ' ', $event->get( 'timezone_name' ) ),
+			'calendar_timezone'   => str_replace( '_', ' ', $default_tz ),
 		);
-		$default_tz = $this->_registry->get( 'date.timezone' )
-			->get_default_timezone();
-		/**
-		 * Only display the timezone information if:
-		 *     -) local timezone is not enforced -- because if it is enforced
-		 *        then site owner knows that it's clear, from event contents,
-		 *        where event happens and what time means;
-		 *     -) the timezone is different from the site timezone because if
-		 *        they do match then it is likely obvious when and wheere the
-		 *        event is about to take place.
-		 */
-		if (
-			$this->_registry->get( 'model.settings' )
-				->get( 'always_use_calendar_timezone' ) &&
-			$event->get( 'timezone_name' ) !== $default_tz
-		) {
-			$timezone_info = array(
-				'show_timezone'       => true,
-				'event_timezone'      => $event->get( 'timezone_name' ),
-				'text_timezone_title' => sprintf(
-					Ai1ec_I18n:: __(
-						'Event was created in the %s time zone'
-					),
-					$event->get( 'start' )->get_gmt_offset_as_text()
-				),
-			);
-		}
 
 		$banner_image_meta = get_post_meta( $event->get( 'post_id' ), 'ai1ec_banner_image' );
 		$banner_image = $banner_image_meta ? $banner_image_meta[0] : '';

--- a/lib/date/time.php
+++ b/lib/date/time.php
@@ -164,8 +164,11 @@ class Ai1ec_Date_Time {
 	 * @return string
 	 */
 	public function get_gmt_offset_as_text() {
-		$offset = $this->_date_time->getOffset() / 3600;
-		return 'GMT' . ( $offset > 0 ? '+' : '' ) . $offset;
+		$offset        = $this->_date_time->getOffset();
+		$offsetHours   = $offset / 3600;
+		$offset        = $offset % 3600;
+		$offsetMinutes = abs( $offset ) / 60;
+		return sprintf( '(GMT%+03d:%02d)', $offsetHours, $offsetMinutes );
 	}
 
 	/**

--- a/public/themes-ai1ec/vortex/twig/event-single.twig
+++ b/public/themes-ai1ec/vortex/twig/event-single.twig
@@ -57,9 +57,10 @@
 		<div class="ai1ec-field-label {{ col1 }}">{{ text_when }}</div>
 		<div class="ai1ec-field-value {{ col2 }} dt-duration">
 			{{ event | timespan | raw }}
-			{% if timezone_info.show_timezone %}
-			<abbr class="ai1ec-initialism ai1ec-tooltip-trigger"
-				title="{{ timezone_info.text_timezone_title | e( 'html_attr' ) }}">{{ timezone_info.event_timezone }}</abbr>
+			{% if timezone_info.using_calendar_tz %}
+				<span>{{ timezone_info.calendar_timezone }}</span>
+			{% else %}
+				<span>{{ timezone_info.event_timezone }}</span>
 			{% endif %}
 			{% include 'recurrence.twig' %}
 		</div>


### PR DESCRIPTION
… an event is not repeating.