### PR TITLE
Prevents duplicate post IDs from being passed to update_meta_cache()

### DIFF
--- a/app/model/search.php
+++ b/app/model/search.php
@@ -188,7 +188,11 @@ class Ai1ec_Event_Search extends Ai1ec_Base {
 		$id_list = array();
 		$id_instance_list = array();
 		foreach ( $events as $event ) {
-			$id_list[] = $event['post_id'];
+
+			if ( ! in_array( $event['post_id'], $id_list, true ) ) {
+				$id_list[] = $event['post_id'];
+			}
+
 			$id_instance_list[] = array(
 				'id'          => $event['post_id'],
 				'instance_id' => $event['instance_id'],


### PR DESCRIPTION
Prevents duplicate post IDs from being passed to update_meta_cache() after searching for events, creating a much smaller database query.

Fixes issue #1222 