### PR TITLE
PROD-2409: "Show the old Post Your Event button above the calendar to…

### DIFF
--- a/app/model/settings.php
+++ b/app/model/settings.php
@@ -847,17 +847,8 @@ class Ai1ec_Settings extends Ai1ec_App {
 				'default'  => false,
 			),
 			'show_create_event_button' => array(
-				'type' => 'bool',
-				'renderer' => array(
-					'class' => 'checkbox',
-					'tab'   => 'editing-events',
-					'label' => Ai1ec_I18n::__(
-						' Show the old <strong>Post Your Event</strong> button above the calendar to privileged users'
-					),
-					'help'  => Ai1ec_I18n::__(
-						'Install the <a target="_blank" href="http://time.ly/">Interactive Frontend Extension</a> for the <strong>frontend Post Your Event form</strong>.'
-					),
-				),
+				'type' => 'deprecated',
+				'renderer' => null,
 				'default'  => false,
 			),
 			'embedding' => array(

--- a/app/model/settings.php
+++ b/app/model/settings.php
@@ -847,7 +847,7 @@ class Ai1ec_Settings extends Ai1ec_App {
 				'default'  => false,
 			),
 			'show_create_event_button' => array(
-				'type' => 'deprecated',
+				'type'     => 'deprecated',
 				'renderer' => null,
 				'default'  => false,
 			),


### PR DESCRIPTION
… privileged users" option still appears in hosted Pro calendar

On settings.php, changed "show_create_event_button" to deprecated.