### PR TITLE
PROD-3150: "Show Post Your Event button above the calendar to privile…

### DIFF
--- a/app/model/settings.php
+++ b/app/model/settings.php
@@ -847,9 +847,18 @@ class Ai1ec_Settings extends Ai1ec_App {
 				'default'  => false,
 			),
 			'show_create_event_button' => array(
-				'type'     => 'deprecated',
-				'renderer' => null,
-				'default'  => false,
+				'type' => 'bool',
+				'renderer' => array(
+ 					'class' => 'checkbox',
+ 					'tab'   => 'extensions',
+ 					'label' => Ai1ec_I18n::__(
+ 						' Show the old <strong>Post Your Event</strong> button above the calendar to privileged users'
+ 					),
+ 					'help'  => Ai1ec_I18n::__(
+ 						'Install the <a target="_blank" href="http://time.ly/">Interactive Frontend Extension</a> for the <strong>frontend Post Your Event form</strong>.'
+ 					),
+ 				),
+				'default'  => true,
 			),
 			'embedding' => array(
 				'type' => 'html',


### PR DESCRIPTION
…ged users" not working

The previous change I made to app/model/settings.php (deprecated **show_create_event_button**) was to fix PROD-2409 ("Show Post Your Event Button" option was being displayed for PRO calendars).
I thought that **show_create_event_button** setting on ai1ecfs.php (fes add-on) would overwrite the **show_create_event_button** on settings.php, which it's not true. So I activated again the setting on settings.php, but only for the tab "extensions".