### PR TITLE
PROD-3527: External Ticket Button Not Displaying on Event Page - Host…

### DIFF
--- a/app/view/event/single.php
+++ b/app/view/event/single.php
@@ -129,7 +129,10 @@ class Ai1ec_View_Event_Single extends Ai1ec_Base {
         $loader = $this->_registry->get( 'theme.loader' );
         $api    = $this->_registry->get( 'model.api.api-ticketing' );
         if ( false === ai1ec_is_blank( $event->get( 'ical_feed_url' ) ) ) {
-            $args['ticket_url'] = $api->get_api_event_buy_ticket_url( $event->get( 'post_id' ) );
+            $ticket_url             = $api->get_api_event_buy_ticket_url( $event->get( 'post_id' ) );
+            if ( ! empty ( $ticket_url ) ) {
+                $args['ticket_url'] = $ticket_url;
+            }
         } else {
             $api_event_id = $api->get_api_event_id( $event->get( 'post_id' ) );
             if ( $api_event_id ) {


### PR DESCRIPTION
…ed Hublite

For imported events, it never displays the ticket button. Updated the method to check if there's a value in the return of $api->get_api_event_buy_ticket_url.
If not, I'm not updating  $args['ticket_url'], since it's initially loaded with $event->ticket_url (which is the proper value)