### PR TITLE
Exceptien handler compatible with PHP7

### DIFF
--- a/lib/exception/handler.php
+++ b/lib/exception/handler.php
@@ -188,7 +188,7 @@ class Ai1ec_Exception_Handler {
      *
      * @return void Exception handler is not expected to return
      */
-    public function handle_exception( Exception $exception ) {
+    public function handle_exception( Throwable $exception ) {
         if ( defined( 'AI1EC_DEBUG' ) && true === AI1EC_DEBUG ) {
             echo '<pre>';
             $this->var_debug( $exception );


### PR DESCRIPTION
Since PHP7, Exceptions thrown from fatal and recoverable errors do not extend Exception. This separation was made to prevent existing PHP 5.x code from catching exceptions thrown from errors that used to halt script execution. Exceptions thrown from fatal and recoverable errors are instances of a new and separate exception class: Error. To unite the two exception branches, Exception and Error both implement a new interface, Throwable.